### PR TITLE
docker on node 4

### DIFF
--- a/step3/frontend/Dockerfile
+++ b/step3/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN cd api && npm install --ignore-scripts
 CMD node api/index.js

--- a/step3/services/serializer/Dockerfile
+++ b/step3/services/serializer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node serializer.js

--- a/step4/frontend/Dockerfile
+++ b/step4/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN cd api && npm install --ignore-scripts
 CMD node api/index.js

--- a/step4/services/broker/Dockerfile
+++ b/step4/services/broker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node broker.js

--- a/step4/services/sensor/Dockerfile
+++ b/step4/services/sensor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node sensor.js

--- a/step4/services/serializer/Dockerfile
+++ b/step4/services/serializer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node serializer.js

--- a/step5/frontend/Dockerfile
+++ b/step5/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN cd api && npm install --ignore-scripts
 CMD node api/index.js

--- a/step5/services/actuator/Dockerfile
+++ b/step5/services/actuator/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node actuator.js

--- a/step5/services/broker/Dockerfile
+++ b/step5/services/broker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node broker.js

--- a/step5/services/sensor/Dockerfile
+++ b/step5/services/sensor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node sensor.js

--- a/step5/services/serializer/Dockerfile
+++ b/step5/services/serializer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node serializer.js

--- a/step6/frontend/Dockerfile
+++ b/step6/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN cd api && npm install --ignore-scripts
 CMD node api/index.js

--- a/step6/services/actuator/Dockerfile
+++ b/step6/services/actuator/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node actuator.js

--- a/step6/services/broker/Dockerfile
+++ b/step6/services/broker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node broker.js

--- a/step6/services/sensor/Dockerfile
+++ b/step6/services/sensor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node sensor.js

--- a/step6/services/serializer/Dockerfile
+++ b/step6/services/serializer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node serializer.js

--- a/step7/frontend/Dockerfile
+++ b/step7/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN cd api && npm install --ignore-scripts
 CMD node api/index.js

--- a/step7/services/actuator/Dockerfile
+++ b/step7/services/actuator/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node actuator.js

--- a/step7/services/broker/Dockerfile
+++ b/step7/services/broker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node broker.js

--- a/step7/services/sensor/Dockerfile
+++ b/step7/services/sensor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node sensor.js

--- a/step7/services/serializer/Dockerfile
+++ b/step7/services/serializer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node serializer.js

--- a/step8/README.md
+++ b/step8/README.md
@@ -3,7 +3,7 @@
 ## solution to step 7
 
 1. you can run the system using docker-compose by running: `docker-compose up` in fuge/
-2. To test that everything is working point your browser to http://<docker-machine-ip>:10001
+2. To test that everything is working point your browser to http://\<docker-machine-ip\>:10001
 
 If you issue a `docker ps` you should see that docker is now running our system
 as a set of containers.

--- a/step8/frontend/Dockerfile
+++ b/step8/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN cd api && npm install --ignore-scripts
 CMD node api/index.js

--- a/step8/services/actuator/Dockerfile
+++ b/step8/services/actuator/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node actuator.js

--- a/step8/services/broker/Dockerfile
+++ b/step8/services/broker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node broker.js

--- a/step8/services/sensor/Dockerfile
+++ b/step8/services/sensor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node sensor.js

--- a/step8/services/serializer/Dockerfile
+++ b/step8/services/serializer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:4
 ADD . /
 RUN npm install --ignore-scripts
 CMD node serializer.js


### PR DESCRIPTION
docker containers built on node 4
fixes the broken dependencies issues. Containers run properly.